### PR TITLE
Change regex to pass code scanning

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-npx lint-staged
-npm test
+yarn lint-staged
+yarn test

--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ exports.reverse = (s) => {
 
 exports.createS3UploadParams = (bucketname, data) => {
   // The synctoken is unix epoch time, using a regex is faster than parsing JSON :)
-  const [, regexToken] = data.match(/syncToken\D+(\d+)/);
+  const [, regexToken] = data.match(/"?syncToken"?:\s?"(\d+)"/);
   return {
     Bucket: bucketname,
     Key: `${exports.reverse(regexToken)}-ipranges.json`,

--- a/test/test.js
+++ b/test/test.js
@@ -39,7 +39,7 @@ const ip_ranges_example = JSON.stringify({
 
 describe("CreateS3UploadParams", function () {
   const tests = [
-    { data: "syncToken: A123", expectedKey: "321-ipranges.json" },
+    { data: '"syncToken": "0123"', expectedKey: "3210-ipranges.json" },
     { data: 'syncToken: "0607"', expectedKey: "7060-ipranges.json" },
     {
       data: ip_ranges_example,


### PR DESCRIPTION
Code Scanning found a polynomial regex that runs against the IP ranges JSON file to extract the timestamp. Using a regex might still be the fastest way in contrast to parsing over 1 Mb of JSON just to extract a single field.