### PR TITLE
Fix update ranges workflow

### DIFF
--- a/.github/workflows/update_ranges.yaml
+++ b/.github/workflows/update_ranges.yaml
@@ -31,13 +31,13 @@ jobs:
         id: ref-to-pull
         with:
           script: |
-            const base_ref = await github.rest.git.getRef({
+            const base_ref = await github.rest.git.listMatchingRefs({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 ref: 'heads/update-ranges'
               });
               console.log(base_ref);
-              return base_ref ? 'update-ranges' : 'master';
+              return len(base_ref.data) > 0 ? 'update-ranges' : 'master';
           result-encoding: string
       - name: Check out repo
         uses: actions/checkout@v3

--- a/.github/workflows/update_ranges.yaml
+++ b/.github/workflows/update_ranges.yaml
@@ -83,4 +83,4 @@ jobs:
           bash -e -x ./history.sh '"${{steps.last-commit-result.outputs.result}}"'
       - name: Push updates to update-ranges branch
         run: |
-          git push origin update-ranges
+          git push origin HEAD:update-ranges

--- a/.github/workflows/update_ranges.yaml
+++ b/.github/workflows/update_ranges.yaml
@@ -10,22 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     name: Update ranges
     steps:
-      - name: Find last commit
-        uses: actions/github-script@v6
-        id: last-commit-result
-        with:
-          script: |
-            const commits = await github.rest.repos.listCommits({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                path: "ip-ranges.json",
-                per_page: 5
-              });
-            console.log(commits);
-            const lastcommit = commits.data[0].commit.author.date;
-            console.log('Last commit on:' + lastcommit)
-            return lastcommit;
-          result-encoding: string
       - name: Find ref to pull
         uses: actions/github-script@v6
         id: ref-to-pull
@@ -37,7 +21,24 @@ jobs:
                 ref: 'heads/update-ranges'
               });
               console.log(base_ref);
-              return len(base_ref.data) > 0 ? 'update-ranges' : 'master';
+              return base_ref.data.length > 0 ? 'update-ranges' : 'master';
+          result-encoding: string
+      - name: Find last commit
+        uses: actions/github-script@v6
+        id: last-commit-result
+        with:
+          script: |
+            const commits = await github.rest.repos.listCommits({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                sha: ${{steps.ref-to-pull.outputs.result}},
+                path: "ip-ranges.json",
+                per_page: 5
+              });
+            console.log(commits.data);
+            const lastcommit = commits.data[0].commit.author.date;
+            console.log('Last commit on:' + lastcommit)
+            return lastcommit;
           result-encoding: string
       - name: Check out repo
         uses: actions/checkout@v3

--- a/.github/workflows/update_ranges.yaml
+++ b/.github/workflows/update_ranges.yaml
@@ -31,7 +31,7 @@ jobs:
             const commits = await github.rest.repos.listCommits({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                sha: ${{steps.ref-to-pull.outputs.result}},
+                sha: "heads/${{steps.ref-to-pull.outputs.result}}",
                 path: "ip-ranges.json",
                 per_page: 5
               });


### PR DESCRIPTION
The Update Ranges workflow can run from either of two starting points:

1. There is no update-ranges branch
2. The update-ranges branch already exists and might have content

Running the workflow twice without any ip range updates in between results in no additional commits on the second run.

To achieve this, we first need to determine if the github repo already has the branch. 

```mermaid
sequenceDiagram
    participant Workflow
    participant GHR as GitHub Repo
    participant S3 as AWS S3
    Workflow->>GHR: Hello does update-ranges exist?
    GHR-->>Workflow: Yes, it does!
    Workflow->>Workflow: Imma gonna use update-ranges
    Workflow->>GHR: Ok, gimme that one.
    GHR-->>Workflow: Sure thing.
    Workflow->>GHR: When was the last time the file was touched?
    GHR-->>Workflow: Happened on 20-12-2023 at 12:11
    Workflow->>S3: Yo, gimme all them files
    S3-->>Workflow: Here you go
    Workflow->>Workflow: Processing files since 20-12-2023 at 12:11
    Workflow->>GHR: These are my commits!
```